### PR TITLE
fix(logs): disabling the advanced terminal behavior when TERM is dumb

### DIFF
--- a/packages/core/src/command.ts
+++ b/packages/core/src/command.ts
@@ -152,7 +152,7 @@ export class Command {
     let progress;
 
     /* istanbul ignore next */
-    if (ci || !process.stderr.isTTY) {
+    if (ci || !process.stderr.isTTY || process.env.TERM === 'dumb') {
       log.disableColor();
       progress = false;
     } else if (!process.stdout.isTTY) {


### PR DESCRIPTION
- ref Lerna issue [#2932](https://github.com/lerna/lerna/pull/2932)